### PR TITLE
[fix] - move logic in regards to freeing resources in RAM and VRAM

### DIFF
--- a/modules/rendering/include/model.h
+++ b/modules/rendering/include/model.h
@@ -65,9 +65,9 @@ namespace Mgtt::Rendering {
         Scene();
 
         /**
-         * @brief Destructor for the scene. Releases resources.
+         * @brief Clear releases resources.
          */
-        ~Scene();
+        void Clear();
         std::string name;
         std::string path;
         glm::vec3 pos;

--- a/modules/rendering/src/model.cpp
+++ b/modules/rendering/src/model.cpp
@@ -15,9 +15,9 @@ Mgtt::Rendering::Scene::Scene() {
 }
 
 /**
- * @brief Destructor for the scene. Releases resources.
+ * @brief Clear releases resources.
  */
-Mgtt::Rendering::Scene::~Scene() {
+void Mgtt::Rendering::Scene::Clear() {
     for (auto& node : this->nodes) {
         this->Linearize(node);
     }


### PR DESCRIPTION
- Move logic in regards to freeing resources in RAM and VRAM to Clear method due to unexpected behavior trough destructor